### PR TITLE
Adjusted OAuth popup dimensions.

### DIFF
--- a/discord_client.js
+++ b/discord_client.js
@@ -34,6 +34,6 @@ Discord.requestCredential = function (options, credentialRequestCompleteCallback
     loginUrl: loginUrl,
     credentialRequestCompleteCallback: credentialRequestCompleteCallback,
     credentialToken: credentialToken,
-    popupOptions: { width: 900, height: 450 }
+    popupOptions: { width: 450, height: 750 }
   });
 };


### PR DESCRIPTION
The dimensions for the OAuth popup are a bit off. The popup is very wide and not very tall, resulting in the user having to resize the popup in order to see what permissions we are requesting.

Pre-fix:
[![Screenshot from Gyazo](https://gyazo.com/a7551e5c02e0384e38650ecbf478bcda/raw)](https://gyazo.com/a7551e5c02e0384e38650ecbf478bcda)

Post-fix: [![Screenshot from Gyazo](https://gyazo.com/3a68dc6fc2e78fda12fc8306ae4d2d86/raw)](https://gyazo.com/3a68dc6fc2e78fda12fc8306ae4d2d86)